### PR TITLE
Handle null $inputArr outside the if/else block

### DIFF
--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -805,7 +805,10 @@ END;
 		} else {
 			$hint = '';
 		}
-
+		// If non-bound statement, $inputarr is false
+		if (!$inputarr) {
+			$inputarr = array();
+		}
 		if ($offset == -1 || ($offset < $this->selectOffsetAlg1 && 0 < $nrows && $nrows < 1000)) {
 			if ($nrows > 0) {
 				if ($offset > 0) {
@@ -813,10 +816,6 @@ END;
 				}
 				$sql = "select * from (".$sql.") where rownum <= :adodb_offset";
 
-				// If non-bound statement, $inputarr is false
-				if (!$inputarr) {
-					$inputarr = array();
-				}
 				$inputarr['adodb_offset'] = $nrows;
 				$nrows = -1;
 			}


### PR DESCRIPTION
I received a php 8.2 deprecation warning:  Automatic conversion of false to array is deprecated.

My code was doing selectLimit with > 1000 rows, which hit the else part of selectLimit.  I see that there was a fix in the if part:
`
if (!$inputarr) {
  $inputarr = array();
}
`

 but not an equivalent fix in the else part.  So I just moved this outside the if/else.